### PR TITLE
Let Monitor use env the argument when sending pings

### DIFF
--- a/lib/Monitor.php
+++ b/lib/Monitor.php
@@ -176,7 +176,7 @@ class Monitor
             'host' => isset($params['host']) ? $params['host'] : gethostname(),
             'metric' => isset($params['metrics']) ? $this->cleanMetrics($params['metrics']) : null,
             'stamp' => microtime(true),
-            'env' => isset($params['env']) ? $params['env'] : null,
+            'env' => isset($params['env']) ? $params['env'] : $this->env,
         ];
 
         $filteredParams = array_filter($cleanedParams, function ($v) {


### PR DESCRIPTION
Setting `environment` when creating Client properly sends the argument to Monitor, but then the argument is completely ignored. As a user I expect that if I specify `environment` when creating the Client, that value is used when sending telemetry unless I specifically set `env` on a ping call.
This PR uses `$this->env` as fallback instead of setting the value to null, so that the behaviour is as specified above.

I wanted to add a test for this behaviour, but there's currently no way to mock `HttpClient` in the tests, and therefor it's not possible to assert on the requests that are being sent.