### PR TITLE
Fix ErrorException "Deprecated: Creation of dynamic …

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -13,6 +13,7 @@ class Client
     public $apiKey;
     public $apiVersion;
     public $monitors;
+    public $environment;
 
     public function __construct($apiKey, $apiVersion = null, $environment = null)
     {


### PR DESCRIPTION
Hello we got this ErrorException with php 8.2. The property needs to be declared 😄 
"Deprecated: Creation of dynamic property Cronitor\Client::$environment is deprecated" 